### PR TITLE
Fixing the PHP 5.5 Compatibility

### DIFF
--- a/tests/beforetests.sh
+++ b/tests/beforetests.sh
@@ -29,6 +29,7 @@ sudo service apache2 restart
 
 mkdir -p $LOGS_DIR
 composer selfupdate
+composer install
 composer update --no-interaction $COMPOSER_FLAGS
 cp app/Resources/webspaces/sulu.io.xml.dist app/Resources/webspaces/sulu.io.xml
 cp app/Resources/pages/overview.xml.dist app/Resources/pages/overview.xml

--- a/tests/beforetests.sh
+++ b/tests/beforetests.sh
@@ -29,7 +29,7 @@ sudo service apache2 restart
 
 mkdir -p $LOGS_DIR
 composer selfupdate
-composer install
+composer install --prefer-dist --no-interaction
 composer update --no-interaction $COMPOSER_FLAGS
 cp app/Resources/webspaces/sulu.io.xml.dist app/Resources/webspaces/sulu.io.xml
 cp app/Resources/pages/overview.xml.dist app/Resources/pages/overview.xml

--- a/tests/beforetests.sh
+++ b/tests/beforetests.sh
@@ -29,8 +29,11 @@ sudo service apache2 restart
 
 mkdir -p $LOGS_DIR
 composer selfupdate
-composer install --prefer-dist --no-interaction
-composer update --no-interaction $COMPOSER_FLAGS
+
+# FIXME hack for prefer-lowest bug: https://github.com/composer/composer/issues/7161
+if [[ $COMPOSER_FLAGS == *"--prefer-lowest"* ]]; then composer install fi
+
+composer update $COMPOSER_FLAGS
 cp app/Resources/webspaces/sulu.io.xml.dist app/Resources/webspaces/sulu.io.xml
 cp app/Resources/pages/overview.xml.dist app/Resources/pages/overview.xml
 cp app/Resources/pages/default.xml.dist app/Resources/pages/default.xml


### PR DESCRIPTION
Hello, @alexander-schranz!

I've noticed you're trying to solve the compatibility for the PHP 5.5, so I got curious and decided to contribute finding the solution.

What I found is the following:

1. The project's dependencies are already suitable with the mentioned version of the PHP language.
2. The problem resides in the absence of the `composer.lock` file and in the preparation of the project for the tests with `beforetests.sh` file.

After checking the history of the `beforetests.sh` file, I saw to @danrot remove the `composer.lock` file and install the dependencies of the project with the `composer update` command, substituting with it the previous `composer install` one, as you can check in 23937c13bbf980d1502cf87895a7dee132c0dd7d.

Handling the dependencies in that way is a risky practice, as it's described in [this article](https://adamcod.es/2013/03/07/composer-install-vs-composer-update.html), which I recommend you to have a look.

I hope this pull request will help you to continue with the project.

Regards.